### PR TITLE
修复一键已读状态并添加腾讯企业邮箱

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -20,7 +20,7 @@ OneMail is a local-first desktop mail client built with Electron, React, and Typ
 
 ## Features
 
-- **Multiple mail accounts**: supports Gmail, Yahoo, Alibaba Mail, Alibaba Mail Enterprise, 189 Mail, Sohu, QQ/Foxmail, NetEase Mail, Outlook/Hotmail, Sina, 139 Mail, 21CN, Perfect Mail, iCloud, AOL, Yandex, Mail.ru, and custom IMAP.
+- **Multiple mail accounts**: supports Gmail, Yahoo, Alibaba Mail, Alibaba Mail Enterprise, 189 Mail, Sohu, Tencent Enterprise Mail, QQ/Foxmail, NetEase Mail, Outlook/Hotmail, Sina, 139 Mail, 21CN, Perfect Mail, iCloud, AOL, Yandex, Mail.ru, and custom IMAP.
 - **Unified inbox**: view mail across accounts with unread counts, sync status, and account actions.
 - **Fast filters**: filter by unread, attachments, starred, today, and more.
 - **Read-state sync**: opening an unread message marks it as read locally and syncs the change back over IMAP.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ OneMail 是一个本地优先的桌面邮件客户端，使用 Electron + React 
 
 ## ✨ 功能特性
 
-- 📬 **多邮箱账号**：支持 Gmail、Yahoo、阿里邮箱、阿里企业邮箱、189、搜狐、QQ/Foxmail、网易、Outlook/Hotmail、新浪、139、21CN、完美邮箱、iCloud、AOL、Yandex、Mail.ru 和自定义 IMAP。
+- 📬 **多邮箱账号**：支持 Gmail、Yahoo、阿里邮箱、阿里企业邮箱、189、搜狐、腾讯企业邮箱、QQ/Foxmail、网易、Outlook/Hotmail、新浪、139、21CN、完美邮箱、iCloud、AOL、Yandex、Mail.ru 和自定义 IMAP。
 - 🧩 **统一收件箱体验**：多账号聚合查看，账号列表展示未读数、同步状态和账号操作。
 - 🔎 **邮件快速筛选**：支持未读、有附件、星标、今日等组合筛选。
 - ✅ **已读状态同步**：打开未读邮件后自动标记已读，并通过 IMAP 同步到远端邮箱。

--- a/src/main/db/repositories/account.repository.ts
+++ b/src/main/db/repositories/account.repository.ts
@@ -472,6 +472,20 @@ function getProviderSmtpPreset(
     }
   }
 
+  if (
+    normalizedProviderKey.includes('tencent_enterprise') ||
+    normalizedProviderKey.includes('exmail') ||
+    domain === 'exmail.qq.com'
+  ) {
+    return {
+      smtpHost: 'smtp.exmail.qq.com',
+      smtpPort: 465,
+      smtpSecurity: 'ssl_tls',
+      smtpAuthType: authType,
+      smtpEnabled: true
+    }
+  }
+
   if (normalizedProviderKey.includes('qq') || domain === 'qq.com' || domain === 'foxmail.com') {
     return {
       smtpHost: 'smtp.qq.com',

--- a/src/renderer/src/components/account/account-form-types.ts
+++ b/src/renderer/src/components/account/account-form-types.ts
@@ -10,6 +10,7 @@ export const accountKinds = [
   'aliyunEnterprise',
   'mail189',
   'sohu',
+  'tencentEnterprise',
   'qq',
   'outlook',
   'netease163',
@@ -146,6 +147,23 @@ export const providerPresets: ProviderPreset[] = [
     passwordLabelKey: 'account.form.independentPassword',
     passwordPlaceholderKey: 'account.form.sohuPasswordPlaceholder',
     guideKey: 'account.add.guide.independentPassword'
+  },
+  {
+    kind: 'tencentEnterprise',
+    labelKey: 'account.provider.tencentEnterprise',
+    providerKey: 'tencent_enterprise',
+    authType: 'app_password',
+    imapHost: 'imap.exmail.qq.com',
+    imapPort: 993,
+    imapSecurity: 'ssl_tls',
+    smtpHost: 'smtp.exmail.qq.com',
+    smtpPort: 465,
+    smtpSecurity: 'ssl_tls',
+    smtpAuthType: 'app_password',
+    smtpEnabled: true,
+    passwordLabelKey: 'account.form.authCode',
+    passwordPlaceholderKey: 'account.form.tencentEnterprisePasswordPlaceholder',
+    guideKey: 'account.add.guide.tencentEnterprise'
   },
   {
     kind: 'qq',

--- a/src/renderer/src/components/account/account-list.tsx
+++ b/src/renderer/src/components/account/account-list.tsx
@@ -409,6 +409,7 @@ function getProviderLabel(providerKey: string, t: (key: TranslationKey) => strin
     aliyunEnterprise: 'account.provider.aliyunEnterprise',
     '189': 'account.provider.mail189',
     sohu: 'account.provider.sohu',
+    tencentEnterprise: 'account.provider.tencentEnterprise',
     sina: 'account.provider.sina',
     '139': 'account.provider.mail139',
     '21cn': 'account.provider.mail21cn',

--- a/src/renderer/src/components/mail/mail-list.tsx
+++ b/src/renderer/src/components/mail/mail-list.tsx
@@ -82,6 +82,7 @@ export function MailList({
   const readCount = Math.max(0, accountMessageCount - account.unread)
   const selectedCount = selectedMessageIds.size
   const hasSelection = selectedCount > 0
+  const canMarkAllRead = account.unread > 0 || messages.some((message) => message.unread)
   const unreadSelectedCount = React.useMemo(
     () => messages.filter((message) => selectedMessageIds.has(message.id) && message.unread).length,
     [messages, selectedMessageIds]
@@ -121,7 +122,7 @@ export function MailList({
           <Button
             size="sm"
             variant="ghost"
-            disabled={selectionDisabled || account.unread === 0 || !onMarkAllRead}
+            disabled={selectionDisabled || !canMarkAllRead || !onMarkAllRead}
             onClick={onMarkAllRead}
           >
             <CheckCheck data-icon="inline-start" />

--- a/src/renderer/src/features/mailbox/mailbox-workspace.tsx
+++ b/src/renderer/src/features/mailbox/mailbox-workspace.tsx
@@ -719,7 +719,7 @@ export function MailboxWorkspace(): React.JSX.Element {
   }
 
   async function handleMarkAllRead(): Promise<void> {
-    if (markingRead || selectedAccount.unread === 0) return
+    if (markingRead) return
 
     try {
       const result = await markCurrentQueryRead(

--- a/src/renderer/src/lib/i18n.tsx
+++ b/src/renderer/src/lib/i18n.tsx
@@ -179,6 +179,7 @@ const zhCN = {
   'account.provider.aliyunEnterprise': '阿里企业邮箱',
   'account.provider.mail189': '电信 189 邮箱',
   'account.provider.sohu': '搜狐邮箱',
+  'account.provider.tencentEnterprise': '腾讯企业邮箱',
   'account.provider.qq': 'QQ / Foxmail 邮箱',
   'account.provider.netease163': '网易邮箱',
   'account.provider.outlook': 'Outlook',
@@ -206,6 +207,7 @@ const zhCN = {
   'account.form.aliyunPasswordPlaceholder': '阿里邮箱三方客户端安全密码',
   'account.form.neteasePasswordPlaceholder': '163 客户端授权码',
   'account.form.qqPasswordPlaceholder': 'QQ 邮箱授权码',
+  'account.form.tencentEnterprisePasswordPlaceholder': '腾讯企业邮箱授权码或客户端专用密码',
   'account.form.aliyunEnterprisePasswordPlaceholder': '阿里企业邮箱密码或专用密码',
   'account.form.mail189PasswordPlaceholder': '189 邮箱登录密码',
   'account.form.sohuPasswordPlaceholder': '搜狐邮箱独立密码',
@@ -254,6 +256,8 @@ const zhCN = {
   'account.add.guide.dedicatedPassword': '添加 {label} 前，建议先开启 IMAP/SMTP 并准备专用密码。',
   'account.add.guide.aliyunEnterprise':
     '添加 {label} 前，建议先让管理员确认已允许三方客户端，并为当前账号开启 IMAP/SMTP；如启用了三方客户端安全密码或安全登录 IP，请准备安全密码并确认当前 IP 被允许。',
+  'account.add.guide.tencentEnterprise':
+    '添加 {label} 前，请先在腾讯企业邮箱后台开启 IMAP/SMTP，并准备授权码或客户端专用密码。',
   'account.add.guide.custom': '添加自定义 IMAP 前，建议先确认服务器、端口、连接安全和密码/授权码。',
   'account.add.guide.default': '添加 {label} 前，如需检查邮箱访问设置，',
   'account.outlook.title': '使用 Microsoft 登录',
@@ -690,6 +694,7 @@ const enUS: TranslationMap = {
   'account.provider.aliyunEnterprise': 'Alibaba Mail Enterprise',
   'account.provider.mail189': '189 Mail',
   'account.provider.sohu': 'Sohu Mail',
+  'account.provider.tencentEnterprise': 'Tencent Enterprise Mail',
   'account.provider.qq': 'QQ / Foxmail',
   'account.provider.netease163': 'NetEase Mail',
   'account.provider.outlook': 'Outlook',
@@ -717,6 +722,8 @@ const enUS: TranslationMap = {
   'account.form.aliyunPasswordPlaceholder': 'Alibaba Mail third-party client security password',
   'account.form.neteasePasswordPlaceholder': '163 client authorization code',
   'account.form.qqPasswordPlaceholder': 'QQ Mail authorization code',
+  'account.form.tencentEnterprisePasswordPlaceholder':
+    'Tencent Enterprise Mail authorization code or app password',
   'account.form.aliyunEnterprisePasswordPlaceholder':
     'Alibaba Mail Enterprise password or dedicated password',
   'account.form.mail189PasswordPlaceholder': '189 Mail login password',
@@ -773,6 +780,8 @@ const enUS: TranslationMap = {
     'Before adding {label}, enable IMAP/SMTP and prepare a dedicated password.',
   'account.add.guide.aliyunEnterprise':
     'Before adding {label}, ask the administrator to allow third-party clients and enable IMAP/SMTP for this account. If third-party client security password or secure login IP restrictions are enabled, prepare the security password and confirm the current IP is allowed.',
+  'account.add.guide.tencentEnterprise':
+    'Before adding {label}, enable IMAP/SMTP in Tencent Enterprise Mail and prepare an authorization code or app password.',
   'account.add.guide.custom':
     'Before adding custom IMAP, confirm the server, port, connection security, and password or authorization code.',
   'account.add.guide.default': 'Before adding {label}, check mailbox access settings if needed, ',

--- a/src/shared/provider-metadata.test.ts
+++ b/src/shared/provider-metadata.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from 'vitest'
+
+import { normalizeProviderKey } from './provider-metadata'
+
+describe('normalizeProviderKey', () => {
+  it('recognizes Tencent Enterprise Mail before generic QQ mail', () => {
+    expect(normalizeProviderKey('tencent_enterprise')).toBe('tencentEnterprise')
+    expect(normalizeProviderKey('imap.exmail.qq.com')).toBe('tencentEnterprise')
+    expect(normalizeProviderKey('qq')).toBe('qq')
+  })
+})

--- a/src/shared/provider-metadata.ts
+++ b/src/shared/provider-metadata.ts
@@ -8,6 +8,7 @@ export type NormalizedProviderKey =
   | 'aliyunEnterprise'
   | '189'
   | 'sohu'
+  | 'tencentEnterprise'
   | 'sina'
   | '139'
   | '21cn'
@@ -35,6 +36,7 @@ const PROVIDER_LOGO_METADATA: Record<string, ProviderLogoMetadata> = {
   aliyunEnterprise: { domain: 'qiye.aliyun.com', fallback: '企' },
   '189': { domain: '189.cn', fallback: '天' },
   sohu: { domain: 'sohu.com', fallback: '狐' },
+  tencentEnterprise: { domain: 'exmail.qq.com', fallback: '企' },
   sina: { domain: 'sina.com', fallback: '新' },
   '139': { domain: '139.com', fallback: '移' },
   '21cn': { domain: '21cn.com', fallback: '21' },
@@ -69,7 +71,6 @@ export function normalizeProviderKey(providerKey?: string): NormalizedProviderKe
   ) {
     return '163'
   }
-  if (normalized.includes('qq') || normalized.includes('foxmail')) return 'qq'
   if (
     normalized.includes('aliyun_enterprise') ||
     normalized.includes('alibaba') ||
@@ -80,6 +81,14 @@ export function normalizeProviderKey(providerKey?: string): NormalizedProviderKe
   if (normalized.includes('aliyun')) return 'aliyun'
   if (normalized.includes('189')) return '189'
   if (normalized.includes('sohu')) return 'sohu'
+  if (
+    normalized.includes('tencent_enterprise') ||
+    normalized.includes('exmail.qq') ||
+    normalized.includes('exmail')
+  ) {
+    return 'tencentEnterprise'
+  }
+  if (normalized.includes('qq') || normalized.includes('foxmail')) return 'qq'
   if (normalized.includes('sina')) return 'sina'
   if (normalized.includes('139')) return '139'
   if (normalized.includes('21cn')) return '21cn'


### PR DESCRIPTION
## 摘要
- 当前邮件列表仍有未读邮件时，即使账号缓存的未读数已过期，也允许执行一键已读
- 添加腾讯企业邮箱预设，包含 IMAP/SMTP 默认配置
- 为 exmail.qq.com 的邮箱服务商归一化补充测试覆盖

## 验证
- pnpm exec vitest run src/shared/provider-metadata.test.ts
- pnpm run typecheck

说明：当前 main 分支的完整 pnpm test 会在主进程相关测试中因 node:sqlite 与 Vite 打包配置失败，这不是本次改动引入的问题。